### PR TITLE
Add more version to the github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "master"
       - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+.[0-9]+"
     paths-ignore:
       - "README.md"
 


### PR DESCRIPTION
These two updates were not detected for the github actions, it can be provoked because the version format of monero package has 4 numbers instead of 3.