### PR TITLE
Port standardization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ FROM debian:bullseye-slim
 
 COPY --from=build /usr/bin/monerod /usr/bin/monerod
 
-ENTRYPOINT monerod --p2p-bind-ip=0.0.0.0 --p2p-bind-port=18080 --rpc-bind-ip=0.0.0.0 --rpc-bind-port=18081 --non-interactive --confirm-external-bind $EXTRA_FLAGS
+ENTRYPOINT monerod --p2p-bind-ip=0.0.0.0 --p2p-bind-port=${P2P_PORT} --rpc-bind-ip=0.0.0.0 --rpc-bind-port=18081 --non-interactive --confirm-external-bind $EXTRA_FLAGS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,12 @@ services:
         UPSTREAM_VERSION: v0.17.3.2
     image: "monero.dnp.dappnode.eth:0.2.3"
     ports:
-      - "18080:18080"
+      - "18089:18089"
       - "18081"
     volumes:
       - "data:/root/.bitmonero"
     environment:
+      - P2P_PORT=18089
       - EXTRA_FLAGS=
 volumes:
   data: {}


### PR DESCRIPTION
According to this issue https://github.com/dappnode/DAppNode/issues/457
We have updated the p2p port:

- Adding an env variable with the value we have defined in that issue
- Add a flag in the dockerfile to change the default port
- Add the ports in the docker-compose network configuration