### PR TITLE
Adding link to apiEngine

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -15,6 +15,7 @@
   "categories": ["Blockchain"],
   "keywords": ["monero"],
   "links": {
+    "apiEngine": "http://monero.dappnode:18081",
     "homepage": "https://github.com/dappnode/DAppNodePackage-monero#readme"
   },
   "repository": {

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -15,7 +15,7 @@
   "categories": ["Blockchain"],
   "keywords": ["monero"],
   "links": {
-    "apiEngine": "http://monero.dappnode:18081",
+    "api": "http://monero.dappnode:18081",
     "homepage": "https://github.com/dappnode/DAppNodePackage-monero#readme"
   },
   "repository": {


### PR DESCRIPTION
Adding the link to the Engine api in the packages section of monero
![Screenshot from 2023-04-18 14-37-54](https://user-images.githubusercontent.com/104903362/232779900-725ceca6-41a7-490e-b6a4-fd31c1685384.png)



