### PR TITLE
bump monero-project/monero to v0.18.3.3

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "monero.dnp.dappnode.eth",
-  "version": "0.2.3",
-  "upstreamVersion": "v0.18.2.2",
+  "version": "0.2.11",
+  "upstreamVersion": "v0.18.3.3",
   "upstreamRepo": "monero-project/monero",
   "shortDescription": "Your own node for the private digital currency",
   "description": "The Monero daemon monerod keeps your computer synced up with the Monero network. It downloads and validates the blockchain from the p2p network. `monerod` is entirely decoupled from your wallet. `monerod` does not access your private keys - it is not aware of your transactions and balance. Read the [monerod reference](https://monerodocs.org/interacting/monerod-reference/) to know all you can do with this DAppNode Package.",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,13 @@ services:
     build:
       context: .
       args:
-        UPSTREAM_VERSION: v0.18.2.2
-    image: "monero.dnp.dappnode.eth:0.2.3"
+        UPSTREAM_VERSION: v0.18.3.3
+    image: monero.dnp.dappnode.eth:0.2.3
     ports:
       - "18089:18089"
       - "18081"
     volumes:
-      - "data:/root/.bitmonero"
+      - data:/root/.bitmonero
     environment:
       - P2P_PORT=18089
       - EXTRA_FLAGS=


### PR DESCRIPTION
Bumps upstream version

- [monero-project/monero](https://github.com/monero-project/monero) from v0.18.2.2 to [v0.18.3.3](https://github.com/monero-project/monero/releases/tag/v0.18.3.3)