### PR TITLE
refactor: use reusable bump-upstream workflow

### DIFF
--- a/.github/workflows/auto_check.yml
+++ b/.github/workflows/auto_check.yml
@@ -1,20 +1,14 @@
 name: Bump upstream version
 
 on:
-  workflow_dispatch: 
   schedule:
     - cron: "00 */4 * * *"
+  workflow_dispatch:
   push:
     branches:
       - "master"
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - run: npx @dappnode/dappnodesdk github-action bump-upstream
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PINATA_API_KEY: ${{ secrets.PINATA_API_KEY }}
-          PINATA_SECRET_API_KEY: ${{ secrets.PINATA_SECRET_API_KEY }}
+  bump-upstream:
+    uses: dappnode/workflows/.github/workflows/bump-upstream.yml@master
+    secrets: inherit


### PR DESCRIPTION
Replace the legacy inline bump-upstream job with the reusable workflow caller from dappnode/workflows.

This preserves the existing scheduled run, manual dispatch, and push trigger on `master`.