### PR TITLE
ci: use dappnode-build-hash reusable workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,13 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - "master"
+    paths-ignore: ["README.md"]
+
+jobs:
+  build:
+    uses: dappnode/workflows/.github/workflows/dappnode-build-hash.yml@master
+    secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,5 @@
 name: "Main"
 on:
-  pull_request:
   push:
     branches:
       - "master"
@@ -8,22 +7,18 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+.[0-9]+"
     paths-ignore:
       - "README.md"
+  workflow_dispatch:
+  repository_dispatch:
 
 jobs:
-  build-test:
-    runs-on: ubuntu-latest
-    name: Build test
-    if: github.event_name != 'push'
-    steps:
-      - uses: actions/checkout@v4
-      - run: npx @dappnode/dappnodesdk build --skip_save
-
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
       - name: Publish
         run: npx @dappnode/dappnodesdk publish patch --dappnode_team_preset
         env:


### PR DESCRIPTION
## Context

This repo'\''s build pipeline (an inlined `build-test` step with `--skip_save`) never pinned to IPFS or posted a comment on PRs, so tropibot bumps had no installable artifact for testers.

## Approach

- `.github/workflows/build.yml` (new) — thin stub calling `dappnode-build-hash@master` with `secrets: inherit`. Triggers on `push` (non-default branch) and `workflow_dispatch` only.
- `.github/workflows/main.yml` — slimmed to the release job only. `build-test` removed; `actions/checkout` upgraded to v7; `actions/setup-node` to v6; Node 24. Dropped the redundant `if:` condition (the `on.push.branches` filter already restricts to master/v*). Added `repository_dispatch` to triggers.

## Test instructions

1. Push a commit to a non-default branch (or open a test PR).
2. Verify the `Build` workflow runs once and posts a comment with an IPFS install link and hash tagged `(by dappnodebot/build-action)` and authored by `tropibot[bot]`.
3. After merge to master, the `Main` workflow should run the release.